### PR TITLE
BAU - remove most option-handling boilerplate from DeclarationXml

### DIFF
--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/AddressXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/AddressXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Elem, Node}
 object AddressXmlWriter {
 
   implicit val addressXmlWriter: XmlWriter[Address] = new XmlWriter[Address] {
-    override def toXml(value: Address): Option[Elem] = {
+    override def toXmlOption(value: Address): Option[Elem] = {
       val typeCode = maybeElement("TypeCode", value.typeCode)
       val cityName = maybeElement("CityName", value.city)
       val countryCode = maybeElement("CountryCode", value.countryCode)

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ArrivalTransportMeansXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ArrivalTransportMeansXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Elem, Node}
 object ArrivalTransportMeansXmlWriter {
 
   implicit val arrivalTransportMeansXmlWriter: XmlWriter[ArrivalTransportMeans] = new XmlWriter[ArrivalTransportMeans] {
-    override def toXml(value: ArrivalTransportMeans): Option[Elem] = {
+    override def toXmlOption(value: ArrivalTransportMeans): Option[Elem] = {
       val id: Option[Node] = maybeElement("ID", value.id)
       val identificationTypeCode: Option[Node] = maybeElement("IdentificationTypeCode", value.identificationTypeCode)
 

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/BorderTransportMeansXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/BorderTransportMeansXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Elem, Node}
 object BorderTransportMeansXmlWriter {
 
   implicit val borderTransportMeansXmlWriter: XmlWriter[BorderTransportMeans] = new XmlWriter[BorderTransportMeans] {
-    override def toXml(value: BorderTransportMeans): Option[Elem] = {
+    override def toXmlOption(value: BorderTransportMeans): Option[Elem] = {
       val registrationNationalityCode: Option[Node] = maybeElement("RegistrationNationalityCode", value.registrationNationalityCode)
       val modeCode: Option[Node] = maybeElement("ModeCode", value.modeCode)
 

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ClassificationXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ClassificationXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Elem, Node}
 object ClassificationXmlWriter {
 
   implicit val classificationXmlWriter: XmlWriter[Classification] = new XmlWriter[Classification] {
-    override def toXml(value: Classification): Option[Elem] = {
+    override def toXmlOption(value: Classification): Option[Elem] = {
       val id: Option[Node] = maybeElement("ID", value.id)
       val identificationTypeCode: Option[Node] = maybeElement("IdentificationTypeCode", value.identificationTypeCode)
 

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ConsignmentXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ConsignmentXmlWriter.scala
@@ -28,11 +28,11 @@ import scala.xml.{Elem, Node}
 object ConsignmentXmlWriter {
 
   implicit val consignmentXmlWriter: XmlWriter[Consignment] = new XmlWriter[Consignment] {
-    override def toXml(value: Consignment): Option[Elem] = {
+    override def toXmlOption(value: Consignment): Option[Elem] = {
       val containerCode: Option[Node] = maybeElement("ContainerCode", value.containerCode)
-      val arrivalTransportMeans: Option[Node] = value.arrivalTransportMeans.flatMap(_.toXml)
-      val goodLocation: Option[Node] = value.goodsLocation.flatMap(_.toXml)
-      val loadingLocation: Option[Node] = value.loadingLocation.flatMap(_.toXml)
+      val loadingLocation: Option[Node] = value.loadingLocation.flatMap(_.toXmlOption)
+      val arrivalTransportMeans: Option[Node] = value.arrivalTransportMeans.flatMap(_.toXmlOption)
+      val goodLocation: Option[Node] = value.goodsLocation.flatMap(_.toXmlOption)
 
       val nodes: List[Node] = List(containerCode, arrivalTransportMeans, goodLocation, loadingLocation).flattenOption
 

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DeclarationXml.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DeclarationXml.scala
@@ -30,7 +30,6 @@ import uk.gov.hmrc.cdsimportsddsfrontend.services.xml.ExportCountryXmlWriter._
 import uk.gov.hmrc.cdsimportsddsfrontend.services.xml.GoodsMeasureXmlWriter._
 import uk.gov.hmrc.cdsimportsddsfrontend.services.xml.OriginXmlWriter._
 import uk.gov.hmrc.cdsimportsddsfrontend.services.xml.PackagingXmlWriter._
-import uk.gov.hmrc.cdsimportsddsfrontend.services.xml.GoodsMeasureXmlWriter._
 import uk.gov.hmrc.cdsimportsddsfrontend.services.xml.HeaderCustomsValuationXmlWriter._
 import uk.gov.hmrc.cdsimportsddsfrontend.services.xml.ItemCustomsValuationXmlWriter._
 
@@ -71,31 +70,31 @@ class DeclarationXml {
           {maybeElement("TypeCode", dec.documentationType.additionalPayment(1).additionalDocPaymentType)}
         </AdditionalDocument>
         {additionalInformation(dec.documentationType.headerAdditionalInformation)}
-        {dec.parties.authorisationHolders.flatMap(_.toXml)}
-        {dec.borderTransportMeans.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
+        {dec.parties.authorisationHolders.map(_.toXml)}
+        {dec.borderTransportMeans.toXml}
         {maybeCurrencyExchange(dec)}
         {maybeParty("Declarant", dec.parties.declarant)}
         {maybeParty("Exporter", dec.parties.exporter)}
         <GoodsShipment>
           <TransactionNatureCode>1</TransactionNatureCode>
           {maybeParty("Buyer", dec.parties.buyer)}
-          {dec.consignment.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
-          {dec.headerCustomsValuation.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
-          {dec.whenAndWhere.destination.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
-          {dec.whenAndWhere.exportCountry.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
+          {dec.consignment.toXml}
+          {dec.headerCustomsValuation.toXml}
+          {dec.whenAndWhere.destination.toXml}
+          {dec.whenAndWhere.exportCountry.toXml}
           <GovernmentAgencyGoodsItem>
             <SequenceNumeric>{dec.declarationType.goodsItemNumber}</SequenceNumeric>
-            {dec.documentationType.additionalDocument.flatMap(_.toXml)}
+            {dec.documentationType.additionalDocument.map(_.toXml)}
             {dec.documentationType.itemAdditionalInformation.map(additionalInformation)}
             <Commodity>
               {maybeElement("Description", dec.commodity.flatMap(_.description))}
-              {dec.commodity.map(_.classification.flatMap(_.toXml)).getOrElse(NodeSeq.Empty)}
+              {dec.commodity.map(_.classification.map(_.toXml)).getOrElse(NodeSeq.Empty)}
               {maybeDutyTaxFee(dec)}
-              {dec.commodity.flatMap(c => c.goodsMeasure).flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
+              {dec.commodity.flatMap(c => c.goodsMeasure).flatMap(_.toXmlOption).getOrElse(NodeSeq.Empty)}
               {maybeInvoiceLine(dec)}
             </Commodity>
-            {dec.itemCustomsValuation.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
-            {dec.parties.domesticDutyTaxParties.flatMap(_.toXml)}
+            {dec.itemCustomsValuation.toXml}
+            {dec.parties.domesticDutyTaxParties.map(_.toXml)}
             <GovernmentProcedure>
               <CurrentCode>{dec.declarationType.requestedProcedureCode}</CurrentCode>
               <PreviousCode>{dec.declarationType.previousProcedureCode}</PreviousCode>
@@ -103,13 +102,13 @@ class DeclarationXml {
             <GovernmentProcedure>
               <CurrentCode>{dec.declarationType.additionalProcedureCode}</CurrentCode>
             </GovernmentProcedure>
-            {dec.whenAndWhere.origin.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
-            {dec.packaging.flatMap(_.toXml).getOrElse(NodeSeq.Empty)}
-            {dec.documentationType.itemPreviousDocument.flatMap(_.toXml)}
+            {dec.whenAndWhere.origin.toXml}
+            {dec.packaging.toXml}
+            {dec.documentationType.itemPreviousDocument.map(_.toXml)}
             {maybeValuationAdjustment(dec)}
           </GovernmentAgencyGoodsItem>
           {maybeParty("Importer", dec.parties.importer)}
-          {dec.documentationType.headerPreviousDocument.flatMap(_.toXml)}
+          {dec.documentationType.headerPreviousDocument.map(_.toXml)}
           {maybeParty("Seller", dec.parties.seller)}
           {maybeTradeTerms(dec)}
           <UCR>
@@ -199,7 +198,7 @@ class DeclarationXml {
         val childNodes =
           maybeElement("Name", party.name) ++
           maybeElement("ID", party.identifier) ++
-          party.address.flatMap(_.toXml).getOrElse(NodeSeq.Empty) ++
+          party.address.flatMap(_.toXmlOption).getOrElse(NodeSeq.Empty) ++
           maybePhoneNumber(party)
         Elem.apply(null, tagName, scala.xml.Null, scala.xml.TopScope, true, childNodes :_*) // scalastyle:ignore
       case None => NodeSeq.Empty

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DestinationXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DestinationXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Elem, Node}
 object DestinationXmlWriter {
 
   implicit val destinationXmlWriter: XmlWriter[Destination] = new XmlWriter[Destination] {
-    override def toXml(value: Destination): Option[Elem] = {
+    override def toXmlOption(value: Destination): Option[Elem] = {
       val id: Option[Node] = maybeElement("CountryCode", value.countryCode)
 
       val nodes: List[Node] = List(id).flattenOption

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ExportCountryXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ExportCountryXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Elem, Node}
 object ExportCountryXmlWriter {
 
   implicit val exportCountryXmlWriter: XmlWriter[ExportCountry] = new XmlWriter[ExportCountry] {
-    override def toXml(value: ExportCountry): Option[Elem] = {
+    override def toXmlOption(value: ExportCountry): Option[Elem] = {
       val id: Option[Node] = maybeElement("ID", value.id)
 
       val nodes: List[Node] = List(id).flattenOption

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsLocationXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsLocationXmlWriter.scala
@@ -26,10 +26,10 @@ import scala.xml.{Elem, Node}
 object GoodsLocationXmlWriter {
 
   implicit val goodsLocationXmlWriter: XmlWriter[GoodsLocation] = new XmlWriter[GoodsLocation] {
-    override def toXml(value: GoodsLocation): Option[Elem] = {
+    override def toXmlOption(value: GoodsLocation): Option[Elem] = {
       val name: Option[Node] = maybeElement("Name", value.name)
       val typeCode: Option[Node] = maybeElement("TypeCode", value.typeCode)
-      val address: Option[Node] = value.address.flatMap(_.toXml)
+      val address: Option[Node] = value.address.flatMap(_.toXmlOption)
 
       val nodes: List[Node] = List(name, typeCode, address).flattenOption
 

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsMeasureXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsMeasureXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Attribute, Elem, Node}
 object GoodsMeasureXmlWriter {
 
   implicit val goodsMeasureXmlWriter: XmlWriter[GoodsMeasure] = new XmlWriter[GoodsMeasure] {
-    override def toXml(value: GoodsMeasure): Option[Elem] = {
+    override def toXmlOption(value: GoodsMeasure): Option[Elem] = {
       val attr = Attribute.apply(pre = "", key = "unitCode", value= "KGM", scala.xml.Null)
 
       val grossMassMeasure: Option[Node] = maybeElement("GrossMassMeasure", value.grossMassMeasure, Some(attr))

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/HeaderCustomsValuationXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/HeaderCustomsValuationXmlWriter.scala
@@ -26,8 +26,8 @@ import scala.xml.{Elem, Node}
 object HeaderCustomsValuationXmlWriter {
 
   implicit val headerCustomsValuationXmlWriter: XmlWriter[HeaderCustomsValuation] = new XmlWriter[HeaderCustomsValuation] {
-    override def toXml(value: HeaderCustomsValuation): Option[Elem] = {
-      val chargeDeduction: Option[Node] = value.chargeDeduction.flatMap(_.toXml)
+    override def toXmlOption(value: HeaderCustomsValuation): Option[Elem] = {
+      val chargeDeduction: Option[Node] = value.chargeDeduction.flatMap(_.toXmlOption)
 
       val nodes: List[Node] = List(chargeDeduction).flattenOption
       Option(nodes).filter(_.nonEmpty).map(nonEmptyChildNodes => <CustomsValuation>{nonEmptyChildNodes}</CustomsValuation>)

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ItemCustomsValuationXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ItemCustomsValuationXmlWriter.scala
@@ -26,9 +26,9 @@ import scala.xml.{Elem, Node}
 object ItemCustomsValuationXmlWriter {
 
   implicit val itemCustomsValuationXmlWriter: XmlWriter[ItemCustomsValuation] = new XmlWriter[ItemCustomsValuation] {
-    override def toXml(value: ItemCustomsValuation): Option[Elem] = {
+    override def toXmlOption(value: ItemCustomsValuation): Option[Elem] = {
       val methodCode: Option[Node] = maybeElement("MethodCode", value.methodCode)
-      val chargeDeduction: Option[Node] = value.chargeDeduction.flatMap(_.toXml)
+      val chargeDeduction: Option[Node] = value.chargeDeduction.flatMap(_.toXmlOption)
 
       val nodes: List[Node] = List(methodCode, chargeDeduction).flattenOption
       Option(nodes).filter(_.nonEmpty).map(nonEmptyChildNodes => <CustomsValuation>{nonEmptyChildNodes}</CustomsValuation>)

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/LoadingLocationXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/LoadingLocationXmlWriter.scala
@@ -23,7 +23,7 @@ import scala.xml.{Elem, Node}
 object LoadingLocationXmlWriter {
 
   implicit val loadingLocationXmlWriter: XmlWriter[LoadingLocation] = new XmlWriter[LoadingLocation] {
-    override def toXml(value: LoadingLocation): Option[Elem] = {
+    override def toXmlOption(value: LoadingLocation): Option[Elem] = {
       val id: Node = element("ID", value.id)
       Some(<LoadingLocation>{id}</LoadingLocation>)
     }

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/OriginXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/OriginXmlWriter.scala
@@ -24,7 +24,7 @@ import scala.xml.{Elem, Node}
 object OriginXmlWriter {
 
   implicit val originXmlWriter: XmlWriter[Origin] = new XmlWriter[Origin] {
-    override def toXml(value: Origin): Option[Elem] = {
+    override def toXmlOption(value: Origin): Option[Elem] = {
       val countryCode: Option[Node] = maybeElement("CountryCode", value.countryCode)
       val typeCode = maybeElement("TypeCode", value.typeCode)
 

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/PackagingXmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/PackagingXmlWriter.scala
@@ -23,7 +23,7 @@ import scala.xml.{Elem, Node}
 object PackagingXmlWriter {
 
   implicit val packagingXmlWriter: XmlWriter[Packaging] = new XmlWriter[Packaging] {
-    override def toXml(value: Packaging): Option[Elem] = {
+    override def toXmlOption(value: Packaging): Option[Elem] = {
       val sequenceNumeric = Some(<SequenceNumeric>1</SequenceNumeric>)
       val marksNumberId = maybeElement("MarksNumbersID", value.marksNumberId)
       val quantityQuantity = maybeElement("QuantityQuantity", value.quantityQuantity)

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlSyntax.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlSyntax.scala
@@ -16,11 +16,22 @@
 
 package uk.gov.hmrc.cdsimportsddsfrontend.services.xml
 
-import scala.xml.Elem
+import scala.xml.{Elem, NodeSeq}
 
 object XmlSyntax {
 
   implicit class XmlWriterOps[A](value: A) {
-    def toXml(implicit writer: XmlWriter[A]): Option[Elem] = writer.toXml(value)
+    def toXml(implicit writer: XmlWriter[A]): NodeSeq = writer.toXml(value)
+    def toXmlOption(implicit writer: XmlWriter[A]): Option[Elem] = writer.toXmlOption(value)
   }
+
+  implicit class OptionXmlWriterOps[A](value: Option[A]) {
+    def toXml(implicit writer: XmlWriter[A]): NodeSeq = {
+      value match {
+        case Some(thing) => thing.toXml
+        case None => NodeSeq.Empty
+      }
+    }
+  }
+
 }

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter.scala
@@ -19,10 +19,15 @@ package uk.gov.hmrc.cdsimportsddsfrontend.services.xml
 import cats.implicits._
 import uk.gov.hmrc.cdsimportsddsfrontend.domain._
 
-import scala.xml.{Attribute, Elem, MetaData, Node, Text}
+import scala.xml.{Attribute, Elem, MetaData, Node, NodeSeq, Text}
 
 trait XmlWriter[A] {
-  def toXml(value: A): Option[Elem]
+
+  def toXml(value: A): NodeSeq = {
+    toXmlOption(value).getOrElse(NodeSeq.Empty)
+  }
+
+  def toXmlOption(value: A): Option[Elem]
 
   protected def maybeElement(elementName: String, maybeElementValue: Option[String], attribute: Option[Attribute] = None): Option[Node] = {
     maybeElementValue.filter(_.nonEmpty).map(value => element(elementName, value, attribute))
@@ -43,7 +48,7 @@ trait XmlWriter[A] {
 object XmlWriterInstances {
 
   implicit val previousDocumentWriter: XmlWriter[PreviousDocument] = new XmlWriter[PreviousDocument] {
-    override def toXml(value: PreviousDocument): Option[Elem] = {
+    override def toXmlOption(value: PreviousDocument): Option[Elem] = {
       val categoryCode: Option[Node] = maybeElement("CategoryCode", value.categoryCode)
       val id = maybeElement("ID", value.id)
       val typeCode = maybeElement("TypeCode", value.typeCode)
@@ -55,7 +60,7 @@ object XmlWriterInstances {
   }
 
   implicit val authorisationHolderWriter: XmlWriter[AuthorisationHolder] = new XmlWriter[AuthorisationHolder] {
-    override def toXml(value: AuthorisationHolder): Option[Elem] = {
+    override def toXmlOption(value: AuthorisationHolder): Option[Elem] = {
       val id = maybeElement("ID", value.identifier)
       val categoryCode = maybeElement("CategoryCode", value.categoryCode)
       val childNodes: List[Node] = List(id, categoryCode).flattenOption
@@ -65,7 +70,7 @@ object XmlWriterInstances {
   }
 
   implicit val domesticDutyTaxPartyWriter: XmlWriter[DomesticDutyTaxParty] = new XmlWriter[DomesticDutyTaxParty] {
-    override def toXml(value: DomesticDutyTaxParty): Option[Elem] = {
+    override def toXmlOption(value: DomesticDutyTaxParty): Option[Elem] = {
       val id = maybeElement("ID", value.identifier)
       val roleCode = maybeElement("RoleCode", value.roleCode)
       val childNodes: List[Node] = List(id, roleCode).flattenOption
@@ -75,7 +80,7 @@ object XmlWriterInstances {
   }
 
   implicit val additionalDocumentWriter: XmlWriter[AdditionalDocumentType] = new XmlWriter[AdditionalDocumentType] {
-    override def toXml( value: AdditionalDocumentType ): Option[Elem] = {
+    override def toXmlOption(value: AdditionalDocumentType ): Option[Elem] = {
       val categoryCode: Option[Node] = maybeElement("CategoryCode", value.categoryCode)
       val id = maybeElement("ID", value.id)
       val name = maybeElement("Name", value.name)
@@ -88,7 +93,7 @@ object XmlWriterInstances {
   }
 
   implicit val chargeDeductionWriter: XmlWriter[ChargeDeduction] = new XmlWriter[ChargeDeduction] {
-    override def toXml(value: ChargeDeduction): Option[Elem] = {
+    override def toXmlOption(value: ChargeDeduction): Option[Elem] = {
       Some(
         <ChargeDeduction>
           <ChargesTypeCode>{value.typeCode}</ChargesTypeCode>

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/AddressXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/AddressXmlWriterSpec.scala
@@ -28,44 +28,44 @@ class AddressXmlWriterSpec extends WordSpec with Matchers with OptionValues {
       "all values are present" in {
         val address = Address(streetAndNumber= Some("StreetNumber"), city = Some("Paris"), countryCode = Some("FR"), postcode = Some("75018"), typeCode = Some("U"))
         val expectedXml = <Address><TypeCode>U</TypeCode><CityName>Paris</CityName><CountryCode>FR</CountryCode><Line>StreetNumber</Line><PostcodeID>75018</PostcodeID></Address>
-        address.toXml shouldBe Some(expectedXml)
+        address.toXmlOption shouldBe Some(expectedXml)
       }
 
       "streetAndNumber is present" in {
         val address = Address(streetAndNumber= Some("StreetNumber"), city = None, countryCode = None, postcode = None, typeCode = None)
         val expectedXml = <Address><Line>StreetNumber</Line></Address>
-        address.toXml shouldBe Some(expectedXml)
+        address.toXmlOption shouldBe Some(expectedXml)
       }
 
       "city is present" in {
         val address = Address(streetAndNumber= None, city = Some("Paris"), countryCode = None, postcode = None, typeCode = None)
         val expectedXml = <Address><CityName>Paris</CityName></Address>
-        address.toXml shouldBe Some(expectedXml)
+        address.toXmlOption shouldBe Some(expectedXml)
       }
 
       "country code is present" in {
         val address = Address(streetAndNumber= None, city = None, countryCode = Some("GB"), postcode = None, typeCode = None)
         val expectedXml = <Address><CountryCode>GB</CountryCode></Address>
-        address.toXml shouldBe Some(expectedXml)
+        address.toXmlOption shouldBe Some(expectedXml)
       }
 
       "post code is present" in {
         val address = Address(streetAndNumber= None, city = None, countryCode = None, postcode = Some("75018"), typeCode = None)
         val expectedXml = <Address><PostcodeID>75018</PostcodeID></Address>
-        address.toXml shouldBe Some(expectedXml)
+        address.toXmlOption shouldBe Some(expectedXml)
       }
 
       "type code is present" in {
         val address = Address(streetAndNumber= None, city = None, countryCode = None, postcode = None, typeCode = Some("U"))
         val expectedXml = <Address><TypeCode>U</TypeCode></Address>
-        address.toXml shouldBe Some(expectedXml)
+        address.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the Address XML element" when {
       "none of the child values are present" in {
         val address = Address(streetAndNumber= None, city = None, countryCode = None, postcode = None, typeCode = None)
-        address.toXml shouldBe None
+        address.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ArrivalTransportMeansXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ArrivalTransportMeansXmlWriterSpec.scala
@@ -28,19 +28,19 @@ class ArrivalTransportMeansXmlWriterSpec extends WordSpec with Matchers with Opt
       "all values are present" in {
         val arrivalTransportMeans = ArrivalTransportMeans(identificationTypeCode = Some("10"), id = Some("1"))
         val expectedXml = <ArrivalTransportMeans><ID>1</ID><IdentificationTypeCode>10</IdentificationTypeCode></ArrivalTransportMeans>
-        arrivalTransportMeans.toXml shouldBe Some(expectedXml)
+        arrivalTransportMeans.toXmlOption shouldBe Some(expectedXml)
       }
 
       "identificationTypeCode is present" in {
         val arrivalTransportMeans = ArrivalTransportMeans(identificationTypeCode = Some("10"), id = None)
         val expectedXml = <ArrivalTransportMeans><IdentificationTypeCode>10</IdentificationTypeCode></ArrivalTransportMeans>
-        arrivalTransportMeans.toXml shouldBe Some(expectedXml)
+        arrivalTransportMeans.toXmlOption shouldBe Some(expectedXml)
       }
 
       "id is present" in {
         val arrivalTransportMeans = ArrivalTransportMeans(identificationTypeCode = None, id = Some("1"))
         val expectedXml = <ArrivalTransportMeans><ID>1</ID></ArrivalTransportMeans>
-        arrivalTransportMeans.toXml shouldBe Some(expectedXml)
+        arrivalTransportMeans.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
@@ -48,7 +48,7 @@ class ArrivalTransportMeansXmlWriterSpec extends WordSpec with Matchers with Opt
       "none of the child values are present" in {
         val arrivalTransportMeans = ArrivalTransportMeans(None, None)
         val expectedXml = <ArrivalTransportMeans><IdentificationTypeCode>10</IdentificationTypeCode><ID>1</ID></ArrivalTransportMeans>
-        arrivalTransportMeans.toXml shouldBe None
+        arrivalTransportMeans.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/BorderTransportMeansXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/BorderTransportMeansXmlWriterSpec.scala
@@ -28,26 +28,26 @@ class BorderTransportMeansXmlWriterSpec extends WordSpec with Matchers with Opti
       "all values are present" in {
         val borderTransportMeans = BorderTransportMeans(registrationNationalityCode = Some("FR"), modeCode = Some("1"))
         val expectedXml = <BorderTransportMeans><RegistrationNationalityCode>FR</RegistrationNationalityCode><ModeCode>1</ModeCode></BorderTransportMeans>
-        borderTransportMeans.toXml shouldBe Some(expectedXml)
+        borderTransportMeans.toXmlOption shouldBe Some(expectedXml)
       }
 
       "registrationNationalityCode is present" in {
         val borderTransportMeans = BorderTransportMeans(registrationNationalityCode = Some("FR"), modeCode = None)
         val expectedXml = <BorderTransportMeans><RegistrationNationalityCode>FR</RegistrationNationalityCode></BorderTransportMeans>
-        borderTransportMeans.toXml shouldBe Some(expectedXml)
+        borderTransportMeans.toXmlOption shouldBe Some(expectedXml)
       }
 
       "modeCode is present" in {
         val borderTransportMeans = BorderTransportMeans(registrationNationalityCode = None, modeCode = Some("1"))
         val expectedXml = <BorderTransportMeans><ModeCode>1</ModeCode></BorderTransportMeans>
-        borderTransportMeans.toXml shouldBe Some(expectedXml)
+        borderTransportMeans.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the BorderTransportMeans XML element" when {
       "none of the child values are present" in {
         val borderTransportMeans = BorderTransportMeans(None, None)
-        borderTransportMeans.toXml shouldBe None
+        borderTransportMeans.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ClassificationXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ClassificationXmlWriterSpec.scala
@@ -28,26 +28,26 @@ class ClassificationXmlWriterSpec extends WordSpec with Matchers with OptionValu
       "all values are present" in {
         val classification = Classification(id = Some("76071111"), identificationTypeCode = Some("TSP"))
         val expectedXml = <Classification><ID>76071111</ID><IdentificationTypeCode>TSP</IdentificationTypeCode></Classification>
-        classification.toXml shouldBe Some(expectedXml)
+        classification.toXmlOption shouldBe Some(expectedXml)
       }
 
       "id is present" in {
         val classification = Classification(id = Some("76071111"), identificationTypeCode = None)
         val expectedXml = <Classification><ID>76071111</ID></Classification>
-        classification.toXml shouldBe Some(expectedXml)
+        classification.toXmlOption shouldBe Some(expectedXml)
       }
 
       "identificationTypeCode is present" in {
         val classification = Classification(id = None, identificationTypeCode = Some("TSP"))
         val expectedXml = <Classification><IdentificationTypeCode>TSP</IdentificationTypeCode></Classification>
-        classification.toXml shouldBe Some(expectedXml)
+        classification.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the Classification XML element" when {
       "none of the child values are present" in {
         val classification = Classification(None, None)
-        classification.toXml shouldBe None
+        classification.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ConsignmentXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ConsignmentXmlWriterSpec.scala
@@ -43,14 +43,14 @@ class ConsignmentXmlWriterSpec extends WordSpec with Matchers with OptionValues 
           </Consignment>
         })
 
-        consignment.toXml shouldBe Some(expectedXml)
+        consignment.toXmlOption shouldBe Some(expectedXml)
       }
 
       "container code is present" in {
         val consignment = Consignment(containerCode = Some("0"), arrivalTransportMeans = None, goodsLocation = None, loadingLocation = None)
         val expectedXml = <Consignment><ContainerCode>0</ContainerCode></Consignment>
 
-        consignment.toXml shouldBe Some(expectedXml)
+        consignment.toXmlOption shouldBe Some(expectedXml)
       }
 
       "arrival transport means is present" in {
@@ -65,7 +65,7 @@ class ConsignmentXmlWriterSpec extends WordSpec with Matchers with OptionValues 
           </Consignment>
         })
 
-        consignment.toXml shouldBe Some(expectedXml)
+        consignment.toXmlOption shouldBe Some(expectedXml)
       }
 
       "goods location is present" in {
@@ -104,14 +104,14 @@ class ConsignmentXmlWriterSpec extends WordSpec with Matchers with OptionValues 
           </Consignment>
         })
 
-        consignment.toXml shouldBe Some(expectedXml)
+        consignment.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the Consignment XML element" when {
       "none of the child values are present" in {
         val consignment = Consignment(None, None, None, None)
-        consignment.toXml shouldBe None
+        consignment.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ConsignmentXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ConsignmentXmlWriterSpec.scala
@@ -87,7 +87,7 @@ class ConsignmentXmlWriterSpec extends WordSpec with Matchers with OptionValues 
           </Consignment>
         })
 
-        consignment.toXml shouldBe Some(expectedXml)
+        consignment.toXmlOption shouldBe Some(expectedXml)
       }
 
       "loading location is present" in {

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DestinationXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DestinationXmlWriterSpec.scala
@@ -29,14 +29,14 @@ class DestinationXmlWriterSpec extends WordSpec with Matchers with OptionValues 
 
         val destination = Destination(countryCode = Some("GB"))
         val expectedXml =  <Destination><CountryCode>GB</CountryCode></Destination>
-        destination.toXml shouldBe Some(expectedXml)
+        destination.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the Destination XML element" when {
       "the ID value is not present" in {
         val destination = Destination(countryCode = None)
-        destination.toXml shouldBe None
+        destination.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ExportCountryXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ExportCountryXmlWriterSpec.scala
@@ -29,14 +29,14 @@ class ExportCountryXmlWriterSpec extends WordSpec with Matchers with OptionValue
 
         val exportCountry = ExportCountry(id = Some("GB"))
         val expectedXml =  <ExportCountry><ID>GB</ID></ExportCountry>
-        exportCountry.toXml shouldBe Some(expectedXml)
+        exportCountry.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the ExportCountry XML element" when {
       "the ID value is not present" in {
         val exportCountry = ExportCountry(id = None)
-        exportCountry.toXml shouldBe None
+        exportCountry.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsLocationXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsLocationXmlWriterSpec.scala
@@ -28,32 +28,32 @@ class GoodsLocationXmlWriterSpec extends WordSpec with Matchers with OptionValue
       "all values are present" in {
         val goodsLocation = GoodsLocation(name = Some("FXFXT"), typeCode = Some("A"), address = Some(Address(None, None, Some("GB"), None, Some("U"))))
         val expectedXml = <GoodsLocation><Name>FXFXT</Name><TypeCode>A</TypeCode><Address><TypeCode>U</TypeCode><CountryCode>GB</CountryCode></Address></GoodsLocation>
-        goodsLocation.toXml shouldBe Some(expectedXml)
+        goodsLocation.toXmlOption shouldBe Some(expectedXml)
       }
 
       "name is present" in {
         val goodsLocation = GoodsLocation(name = Some("FXFXT"), typeCode = None, address = None)
         val expectedXml = <GoodsLocation><Name>FXFXT</Name></GoodsLocation>
-        goodsLocation.toXml shouldBe Some(expectedXml)
+        goodsLocation.toXmlOption shouldBe Some(expectedXml)
       }
 
       "type code is present" in {
         val goodsLocation = GoodsLocation(name = None, typeCode = Some("A"), address = None)
         val expectedXml = <GoodsLocation><TypeCode>A</TypeCode></GoodsLocation>
-        goodsLocation.toXml shouldBe Some(expectedXml)
+        goodsLocation.toXmlOption shouldBe Some(expectedXml)
       }
 
       "address is present" in {
         val goodsLocation = GoodsLocation(name = None, typeCode = None, address = Some(Address(None, None, Some("GB"), None, Some("U"))))
         val expectedXml = <GoodsLocation><Address><TypeCode>U</TypeCode><CountryCode>GB</CountryCode></Address></GoodsLocation>
-        goodsLocation.toXml shouldBe Some(expectedXml)
+        goodsLocation.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the Goods Location XML element" when {
       "none of the child values are present" in {
         val goodsLocation = GoodsLocation(name = None, typeCode = None, address = None)
-        goodsLocation.toXml shouldBe None
+        goodsLocation.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsMeasureXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/GoodsMeasureXmlWriterSpec.scala
@@ -29,25 +29,25 @@ class GoodsMeasureXmlWriterSpec extends WordSpec with Matchers with OptionValues
 
         val actual = GoodsMeasure(netNetWeightMeasure = Some("101"), tariffQuantity = Some("99"), grossMassMeasure = Some("88"))
         val expectedXml =  <GoodsMeasure><GrossMassMeasure unitCode="KGM">88</GrossMassMeasure><NetNetWeightMeasure unitCode="KGM">101</NetNetWeightMeasure><TariffQuantity>99</TariffQuantity></GoodsMeasure>
-        actual.toXml shouldBe Some(expectedXml)
+        actual.toXmlOption shouldBe Some(expectedXml)
       }
 
       "gross mass measure is present" in {
         val actual = GoodsMeasure(grossMassMeasure = Some("88"))
         val expectedXml =  <GoodsMeasure><GrossMassMeasure unitCode="KGM">88</GrossMassMeasure></GoodsMeasure>
-        actual.toXml shouldBe Some(expectedXml)
+        actual.toXmlOption shouldBe Some(expectedXml)
       }
 
       "net net weight measure is present" in {
         val actual = GoodsMeasure(netNetWeightMeasure = Some("102"))
         val expectedXml =  <GoodsMeasure><NetNetWeightMeasure unitCode="KGM">102</NetNetWeightMeasure></GoodsMeasure>
-        actual.toXml shouldBe Some(expectedXml)
+        actual.toXmlOption shouldBe Some(expectedXml)
       }
 
       "tariff quantity is present" in {
         val actual = GoodsMeasure(tariffQuantity = Some("11"))
         val expectedXml =  <GoodsMeasure><TariffQuantity>11</TariffQuantity></GoodsMeasure>
-        actual.toXml shouldBe Some(expectedXml)
+        actual.toXmlOption shouldBe Some(expectedXml)
       }
 
     }
@@ -55,7 +55,7 @@ class GoodsMeasureXmlWriterSpec extends WordSpec with Matchers with OptionValues
     "not generate the GoodsMeasure XML element" when {
       "non of the child values are present" in {
         val goodsMeasure = GoodsMeasure()
-        goodsMeasure.toXml shouldBe None
+        goodsMeasure.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/HeaderCustomsValuationXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/HeaderCustomsValuationXmlWriterSpec.scala
@@ -43,14 +43,14 @@ class HeaderCustomsValuationXmlWriterSpec extends WordSpec with Matchers with Op
           </CustomsValuation>
         })
 
-        headerCustomsValuation.toXml.map(Utility.trim(_)) shouldBe Some(expectedXml)
+        headerCustomsValuation.toXmlOption.map(Utility.trim(_)) shouldBe Some(expectedXml)
       }
     }
 
     "not generate the HeaderCustomsValuation XML element" when {
       "non of the child values are present" in {
         val headerCustomsValuation = HeaderCustomsValuation(chargeDeduction = None)
-        headerCustomsValuation.toXml shouldBe None
+        headerCustomsValuation.toXmlOption shouldBe None
       }
     }
 

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ItemCustomsValuationXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/ItemCustomsValuationXmlWriterSpec.scala
@@ -45,14 +45,14 @@ class ItemCustomsValuationXmlWriterSpec extends WordSpec with Matchers with Opti
           </CustomsValuation>
         })
 
-        itemCustomsValuation.toXml.map(Utility.trim(_)) shouldBe Some(expectedXml)
+        itemCustomsValuation.toXmlOption.map(Utility.trim(_)) shouldBe Some(expectedXml)
       }
     }
 
     "not generate the ItemCustomsValuation XML element" when {
       "non of the child values are present" in {
         val itemCustomsValuation = ItemCustomsValuation(methodCode =  None, chargeDeduction = None)
-        itemCustomsValuation.toXml shouldBe None
+        itemCustomsValuation.toXmlOption shouldBe None
       }
     }
 

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/LoadingLocationXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/LoadingLocationXmlWriterSpec.scala
@@ -29,7 +29,7 @@ class LoadingLocationXmlWriterSpec extends WordSpec with Matchers with OptionVal
 
         val loadingLocation = LoadingLocation("LHR")
         val expectedXml =  <LoadingLocation><ID>LHR</ID></LoadingLocation>
-        loadingLocation.toXml shouldBe Some(expectedXml)
+        loadingLocation.toXmlOption shouldBe Some(expectedXml)
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/OriginXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/OriginXmlWriterSpec.scala
@@ -29,26 +29,26 @@ class OriginXmlWriterSpec extends WordSpec with Matchers with OptionValues {
 
         val origin = Origin(countryCode = Some("GB"), typeCode = Some("99"))
         val expectedXml =  <Origin><CountryCode>GB</CountryCode><TypeCode>99</TypeCode></Origin>
-        origin.toXml shouldBe Some(expectedXml)
+        origin.toXmlOption shouldBe Some(expectedXml)
       }
 
       "country code is present" in {
         val origin = Origin(countryCode = Some("GB"), typeCode = None)
         val expectedXml =  <Origin><CountryCode>GB</CountryCode></Origin>
-        origin.toXml shouldBe Some(expectedXml)
+        origin.toXmlOption shouldBe Some(expectedXml)
       }
 
       "type code is present" in {
         val origin = Origin(countryCode = None, typeCode = Some("99"))
         val expectedXml =  <Origin><TypeCode>99</TypeCode></Origin>
-        origin.toXml shouldBe Some(expectedXml)
+        origin.toXmlOption shouldBe Some(expectedXml)
       }
     }
 
     "not generate the Origin XML element" when {
       "non of the child values are present" in {
         val origin = Origin(countryCode = None, typeCode = None)
-        origin.toXml shouldBe None
+        origin.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/PackagingXmlWriterSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/PackagingXmlWriterSpec.scala
@@ -29,28 +29,28 @@ class PackagingXmlWriterSpec extends WordSpec with Matchers with OptionValues {
 
         val packaging = Packaging(typeCode = Some("TC"), quantityQuantity = Some("88"), marksNumberId = Some("MK123"))
         val expectedXml = <Packaging><SequenceNumeric>1</SequenceNumeric><MarksNumbersID>MK123</MarksNumbersID><QuantityQuantity>88</QuantityQuantity><TypeCode>TC</TypeCode></Packaging>
-        packaging.toXml shouldBe Some(expectedXml)
+        packaging.toXmlOption shouldBe Some(expectedXml)
       }
 
       "MarksNumbersID is the only value present" in {
 
         val packaging = Packaging(marksNumberId = Some("MK1234"))
         val expectedXml = <Packaging><SequenceNumeric>1</SequenceNumeric><MarksNumbersID>MK1234</MarksNumbersID></Packaging>
-        packaging.toXml shouldBe Some(expectedXml)
+        packaging.toXmlOption shouldBe Some(expectedXml)
       }
 
       "QuantityQuantity is the only value present" in {
 
         val packaging = Packaging(quantityQuantity = Some("99"))
         val expectedXml = <Packaging><SequenceNumeric>1</SequenceNumeric><QuantityQuantity>99</QuantityQuantity></Packaging>
-        packaging.toXml shouldBe Some(expectedXml)
+        packaging.toXmlOption shouldBe Some(expectedXml)
       }
 
       "TypeCode is the only value present" in {
 
         val packaging = Packaging(typeCode = Some("TC1"))
         val expectedXml = <Packaging><SequenceNumeric>1</SequenceNumeric><TypeCode>TC1</TypeCode></Packaging>
-        packaging.toXml shouldBe Some(expectedXml)
+        packaging.toXmlOption shouldBe Some(expectedXml)
       }
 
     }
@@ -58,7 +58,7 @@ class PackagingXmlWriterSpec extends WordSpec with Matchers with OptionValues {
     "not generate the Packaging XML element" when {
       "non of the child values are present" in {
         val packaging = Packaging()
-        packaging.toXml shouldBe None
+        packaging.toXmlOption shouldBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_AdditionalDocumentSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_AdditionalDocumentSpec.scala
@@ -38,7 +38,7 @@ class XmlWriter_AdditionalDocumentSpec extends WordSpec with Matchers with Optio
       "all parameters are Some and not empty spaces" in {
         val expectedResultAll = Some(<AdditionalDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><Name>name_1</Name><TypeCode>typeCode_1</TypeCode><LPCOExemptionCode>lpco_1</LPCOExemptionCode></AdditionalDocument>)
 
-        additionalDocumentAll.toXml shouldBe expectedResultAll
+        additionalDocumentAll.toXmlOption shouldBe expectedResultAll
       }
     }
 
@@ -51,21 +51,21 @@ class XmlWriter_AdditionalDocumentSpec extends WordSpec with Matchers with Optio
       name = None
       )
 
-      additionalDocumentEmpty.toXml shouldBe None
+      additionalDocumentEmpty.toXmlOption shouldBe None
     }
 
     "not return an element for a field which has an empty string" in {
       val additionalDocumentWithEmptyString = additionalDocumentAll.copy(typeCode = Some(""))
       val expectedResultWithEmptyString = Some(<AdditionalDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><Name>name_1</Name><LPCOExemptionCode>lpco_1</LPCOExemptionCode></AdditionalDocument>)
 
-      additionalDocumentWithEmptyString.toXml shouldBe expectedResultWithEmptyString
+      additionalDocumentWithEmptyString.toXmlOption shouldBe expectedResultWithEmptyString
     }
 
     "return elements only for fields containing some text" in {
       val additionalDocumentMixed = additionalDocumentAll.copy(categoryCode = Some(""), lpco = Some(""))
       val expectedResultMixed = Some(<AdditionalDocument><ID>id_1</ID><Name>name_1</Name><TypeCode>typeCode_1</TypeCode></AdditionalDocument>)
 
-      additionalDocumentMixed.toXml shouldBe expectedResultMixed
+      additionalDocumentMixed.toXmlOption shouldBe expectedResultMixed
     }
 
     emptyFields foreach { value =>
@@ -74,7 +74,7 @@ class XmlWriter_AdditionalDocumentSpec extends WordSpec with Matchers with Optio
         val expectedResultWithoutCategoryCode =
           Some(<AdditionalDocument><ID>id_1</ID><Name>name_1</Name><TypeCode>typeCode_1</TypeCode><LPCOExemptionCode>lpco_1</LPCOExemptionCode></AdditionalDocument>)
 
-        additionalDocumentWithoutCategoryCode.toXml shouldBe expectedResultWithoutCategoryCode
+        additionalDocumentWithoutCategoryCode.toXmlOption shouldBe expectedResultWithoutCategoryCode
       }
     }
 
@@ -83,7 +83,7 @@ class XmlWriter_AdditionalDocumentSpec extends WordSpec with Matchers with Optio
         val additionalDocumentWithoutId = additionalDocumentAll.copy(id = value)
         val expectedResultWithoutId =Some(<AdditionalDocument><CategoryCode>category_1</CategoryCode><Name>name_1</Name><TypeCode>typeCode_1</TypeCode><LPCOExemptionCode>lpco_1</LPCOExemptionCode></AdditionalDocument>)
 
-        additionalDocumentWithoutId.toXml shouldBe expectedResultWithoutId
+        additionalDocumentWithoutId.toXmlOption shouldBe expectedResultWithoutId
       }
     }
 
@@ -92,7 +92,7 @@ class XmlWriter_AdditionalDocumentSpec extends WordSpec with Matchers with Optio
         val additionalDocumentWithoutTypeCode = additionalDocumentAll.copy(typeCode = value)
         val expectedResultWithoutTypeCode =Some(<AdditionalDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><Name>name_1</Name><LPCOExemptionCode>lpco_1</LPCOExemptionCode></AdditionalDocument>)
 
-        additionalDocumentWithoutTypeCode.toXml shouldBe expectedResultWithoutTypeCode
+        additionalDocumentWithoutTypeCode.toXmlOption shouldBe expectedResultWithoutTypeCode
       }
     }
 
@@ -101,7 +101,7 @@ class XmlWriter_AdditionalDocumentSpec extends WordSpec with Matchers with Optio
         val additionalDocumentWithoutLpco = additionalDocumentAll.copy(lpco = value)
         val expectedResultWithoutLpco =Some(<AdditionalDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><Name>name_1</Name><TypeCode>typeCode_1</TypeCode></AdditionalDocument>)
 
-        additionalDocumentWithoutLpco.toXml shouldBe expectedResultWithoutLpco
+        additionalDocumentWithoutLpco.toXmlOption shouldBe expectedResultWithoutLpco
       }
     }
 
@@ -110,7 +110,7 @@ class XmlWriter_AdditionalDocumentSpec extends WordSpec with Matchers with Optio
         val additionalDocumentWithoutName = additionalDocumentAll.copy(name = value)
         val expectedResultWithoutName =Some(<AdditionalDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><TypeCode>typeCode_1</TypeCode><LPCOExemptionCode>lpco_1</LPCOExemptionCode></AdditionalDocument>)
 
-        additionalDocumentWithoutName.toXml shouldBe expectedResultWithoutName
+        additionalDocumentWithoutName.toXmlOption shouldBe expectedResultWithoutName
       }
     }
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_AuthorisationHolderSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_AuthorisationHolderSpec.scala
@@ -33,13 +33,13 @@ class XmlWriter_AuthorisationHolderSpec extends WordSpec with Matchers with Opti
       "all parameters are Some" in {
           val expectedResultAll =
             <AuthorisationHolder><ID>id_1</ID><CategoryCode>category_1</CategoryCode></AuthorisationHolder>
-        authorisationHolderAll.toXml shouldBe (Some(expectedResultAll))
+        authorisationHolderAll.toXmlOption shouldBe (Some(expectedResultAll))
       }
     }
 
     "return no AuthorisationHolder node when all fields are None" in {
       val authorisationHolderEmpty = AuthorisationHolder(None, None)
-      authorisationHolderEmpty.toXml shouldBe None
+      authorisationHolderEmpty.toXmlOption shouldBe None
     }
 
     List(Some(""), None) foreach { emptyValue =>
@@ -47,7 +47,7 @@ class XmlWriter_AuthorisationHolderSpec extends WordSpec with Matchers with Opti
         val authorisationHolderWithoutId = authorisationHolderAll.copy(identifier = emptyValue)
         val expectedResultWithoutId =
           <AuthorisationHolder><CategoryCode>category_1</CategoryCode></AuthorisationHolder>
-        authorisationHolderWithoutId.toXml shouldBe Some(expectedResultWithoutId)
+        authorisationHolderWithoutId.toXmlOption shouldBe Some(expectedResultWithoutId)
       }
     }
 
@@ -56,7 +56,7 @@ class XmlWriter_AuthorisationHolderSpec extends WordSpec with Matchers with Opti
         val authorisationHolderWithoutCategoryCode = authorisationHolderAll.copy(categoryCode = emptyValue)
         val expectedResultWithoutCategoryCode =
           <AuthorisationHolder><ID>id_1</ID></AuthorisationHolder>
-        authorisationHolderWithoutCategoryCode.toXml shouldBe Some(expectedResultWithoutCategoryCode)
+        authorisationHolderWithoutCategoryCode.toXmlOption shouldBe Some(expectedResultWithoutCategoryCode)
       }
     }
 

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_ChargeDeductionSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_ChargeDeductionSpec.scala
@@ -32,7 +32,7 @@ class XmlWriter_ChargeDeductionSpec extends WordSpec with Matchers with OptionVa
           <ChargesTypeCode>FOO</ChargesTypeCode>
           <OtherChargeDeductionAmount currencyID="SEK">10203</OtherChargeDeductionAmount>
         </ChargeDeduction>
-      chargeDeduction.toXml shouldBe (Some(expectedXml))
+      chargeDeduction.toXmlOption shouldBe (Some(expectedXml))
     }
 
   }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_DomesticDutyTaxPartySpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_DomesticDutyTaxPartySpec.scala
@@ -33,13 +33,13 @@ class XmlWriter_DomesticDutyTaxPartySpec extends WordSpec with Matchers with Opt
       "all parameters are Some" in {
           val expectedResultAll =
             <DomesticDutyTaxParty><ID>id_1</ID><RoleCode>role_1</RoleCode></DomesticDutyTaxParty>
-        domesticDutyTaxPartyAll.toXml shouldBe (Some(expectedResultAll))
+        domesticDutyTaxPartyAll.toXmlOption shouldBe (Some(expectedResultAll))
       }
     }
 
     "return no DomesticDutyTaxParty node when all fields are None" in {
       val domesticDutyTaxPartyEmpty = DomesticDutyTaxParty(None, None)
-      domesticDutyTaxPartyEmpty.toXml shouldBe None
+      domesticDutyTaxPartyEmpty.toXmlOption shouldBe None
     }
 
     List(Some(""), None) foreach { emptyValue =>
@@ -47,7 +47,7 @@ class XmlWriter_DomesticDutyTaxPartySpec extends WordSpec with Matchers with Opt
         val domesticDutyTaxPartyWithoutId = domesticDutyTaxPartyAll.copy(identifier = emptyValue)
         val expectedResultWithoutId =
           <DomesticDutyTaxParty><RoleCode>role_1</RoleCode></DomesticDutyTaxParty>
-        domesticDutyTaxPartyWithoutId.toXml shouldBe Some(expectedResultWithoutId)
+        domesticDutyTaxPartyWithoutId.toXmlOption shouldBe Some(expectedResultWithoutId)
       }
     }
 
@@ -56,7 +56,7 @@ class XmlWriter_DomesticDutyTaxPartySpec extends WordSpec with Matchers with Opt
         val domesticDutyTaxPartyWithoutRoleCode = domesticDutyTaxPartyAll.copy(roleCode = emptyValue)
         val expectedResultWithoutRoleCode =
           <DomesticDutyTaxParty><ID>id_1</ID></DomesticDutyTaxParty>
-        domesticDutyTaxPartyWithoutRoleCode.toXml shouldBe Some(expectedResultWithoutRoleCode)
+        domesticDutyTaxPartyWithoutRoleCode.toXmlOption shouldBe Some(expectedResultWithoutRoleCode)
       }
     }
 

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_PreviousDocumentSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/XmlWriter_PreviousDocumentSpec.scala
@@ -35,7 +35,7 @@ class XmlWriter_PreviousDocumentSpec extends WordSpec with Matchers with OptionV
       "all parameters are Some" in {
           val expectedResultAll =
             <PreviousDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><TypeCode>typeclass_1</TypeCode><LineNumeric>linenumeric_1</LineNumeric></PreviousDocument>
-        previousDocumentAll.toXml shouldBe (Some(expectedResultAll))
+        previousDocumentAll.toXmlOption shouldBe (Some(expectedResultAll))
       }
     }
 
@@ -46,21 +46,21 @@ class XmlWriter_PreviousDocumentSpec extends WordSpec with Matchers with OptionV
         typeCode = None,
         lineNumeric = None
       )
-      previousDocumentEmpty.toXml shouldBe None
+      previousDocumentEmpty.toXmlOption shouldBe None
     }
 
     "return no element for a field which has an empty string" in {
       val previousDocumentWithEmptyString = previousDocumentAll.copy(typeCode = Some(""))
       val expectedResultWithEmptyString =
         <PreviousDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><LineNumeric>linenumeric_1</LineNumeric></PreviousDocument>
-      previousDocumentWithEmptyString.toXml shouldBe Some(expectedResultWithEmptyString)
+      previousDocumentWithEmptyString.toXmlOption shouldBe Some(expectedResultWithEmptyString)
     }
 
     "return elements only for fields containing some text" in {
       val previousDocumentMixed = previousDocumentAll.copy(categoryCode = None, lineNumeric = Some(""))
       val expectedResultMixed =
         <PreviousDocument><ID>id_1</ID><TypeCode>typeclass_1</TypeCode></PreviousDocument>
-      previousDocumentMixed.toXml shouldBe Some(expectedResultMixed)
+      previousDocumentMixed.toXmlOption shouldBe Some(expectedResultMixed)
     }
 
     List(Some(""), None) foreach { value =>
@@ -68,7 +68,7 @@ class XmlWriter_PreviousDocumentSpec extends WordSpec with Matchers with OptionV
         val previousDocumentWithoutCategoryCode = previousDocumentAll.copy(categoryCode = value)
         val expectedResultWithoutCategoryCode =
           <PreviousDocument><ID>id_1</ID><TypeCode>typeclass_1</TypeCode><LineNumeric>linenumeric_1</LineNumeric></PreviousDocument>
-        previousDocumentWithoutCategoryCode.toXml shouldBe Some(expectedResultWithoutCategoryCode)
+        previousDocumentWithoutCategoryCode.toXmlOption shouldBe Some(expectedResultWithoutCategoryCode)
       }
     }
 
@@ -77,7 +77,7 @@ class XmlWriter_PreviousDocumentSpec extends WordSpec with Matchers with OptionV
         val previousDocumentWithoutId = previousDocumentAll.copy(id = value)
         val expectedResultWithoutId =
           <PreviousDocument><CategoryCode>category_1</CategoryCode><TypeCode>typeclass_1</TypeCode><LineNumeric>linenumeric_1</LineNumeric></PreviousDocument>
-        previousDocumentWithoutId.toXml shouldBe Some(expectedResultWithoutId)
+        previousDocumentWithoutId.toXmlOption shouldBe Some(expectedResultWithoutId)
       }
     }
 
@@ -86,7 +86,7 @@ class XmlWriter_PreviousDocumentSpec extends WordSpec with Matchers with OptionV
         val previousDocumentWithoutTypeCode = previousDocumentAll.copy(typeCode = value)
         val expectedResultWithoutTypeCode =
           <PreviousDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><LineNumeric>linenumeric_1</LineNumeric></PreviousDocument>
-        previousDocumentWithoutTypeCode.toXml shouldBe Some(expectedResultWithoutTypeCode)
+        previousDocumentWithoutTypeCode.toXmlOption shouldBe Some(expectedResultWithoutTypeCode)
       }
     }
 
@@ -95,7 +95,7 @@ class XmlWriter_PreviousDocumentSpec extends WordSpec with Matchers with OptionV
         val previousDocumentWithoutLineNumeric = previousDocumentAll.copy(lineNumeric = value)
         val expectedResultWithoutLineNumeric =
           <PreviousDocument><CategoryCode>category_1</CategoryCode><ID>id_1</ID><TypeCode>typeclass_1</TypeCode></PreviousDocument>
-        previousDocumentWithoutLineNumeric.toXml shouldBe Some(expectedResultWithoutLineNumeric)
+        previousDocumentWithoutLineNumeric.toXmlOption shouldBe Some(expectedResultWithoutLineNumeric)
       }
     }
 


### PR DESCRIPTION
- rename `toXml` to `toXmlOption` (since that's what it is)
- add `toXml` wrapper, returning `NodeSeq`
- add implicit `toXml` for `Option[_]`