### PR TITLE
CDSID-1217 - Remove the WhenAndWhere class form the domain

### DIFF
--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/controllers/model/DeclarationViewModel.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/controllers/model/DeclarationViewModel.scala
@@ -42,7 +42,6 @@ case class DeclarationViewModel(
       documentationType = documentationType,
       parties = parties,
       valuationInformationAndTaxes = valuationInformationAndTaxesViewModel.toValuationInformationAndTaxes,
-      whenAndWhere = whenAndWhereViewModel.toWhenAndWhere,
       totalGrossMassMeasure = goodsIdentification.grossMass,
       commodity = Some(Commodity(
         goodsMeasure = Some(goodsIdentification.toGoodsMeasure),
@@ -52,7 +51,11 @@ case class DeclarationViewModel(
       borderTransportMeans = Some(transportInformationViewModel.toBorderTransportMeans),
       consignment = Some(consignment),
       headerCustomsValuation = Some(valuationInformationAndTaxesViewModel.toHeaderCustomsValuation),
-      itemCustomsValuation = Some(valuationInformationAndTaxesViewModel.toItemCustomsValuation)
+      itemCustomsValuation = Some(valuationInformationAndTaxesViewModel.toItemCustomsValuation),
+      goodsShipment = GoodsShipment(destination = whenAndWhereViewModel.destination,
+                                    exportCountry = whenAndWhereViewModel.exportCountry,
+                                    governmentAgencyGoodsItem = Some(GovernmentAgencyGoodsItem(origin = whenAndWhereViewModel.origin))
+      )
     )
   }
 }

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/controllers/model/WhenAndWhereViewModel.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/controllers/model/WhenAndWhereViewModel.scala
@@ -18,16 +18,11 @@ package uk.gov.hmrc.cdsimportsddsfrontend.controllers.model
 
 import uk.gov.hmrc.cdsimportsddsfrontend.domain._
 
-case class WhenAndWhereViewModel(destination: Option[Destination] = Some(Destination()),
+case class WhenAndWhereViewModel(
+                        destination: Option[Destination] = Some(Destination()),
                         exportCountry: Option[ExportCountry] = Some(ExportCountry()),
                         origin: Option[Origin] = Some(Origin()),
                         goodsLocation: Option[GoodsLocation] = Some(GoodsLocation(
                           Some("FXTFXTFXT"), Some("A"), Some(Address(
                             streetAndNumber = None, city = None, countryCode = Some("GB"), postcode = None, typeCode = Some("U"))))),
-                                 placeOfLoading: Option[String] = Some("JFK")
-                                ) {
-
-  def toWhenAndWhere: WhenAndWhere = {
-    WhenAndWhere(destination, exportCountry, origin)
-  }
-}
+                        placeOfLoading: Option[String] = Some("JFK"))

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/domain/Declaration.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/domain/Declaration.scala
@@ -21,12 +21,14 @@ case class Declaration(
                         documentationType: DocumentationType = DocumentationType(),
                         parties: DeclarationParties = DeclarationParties(),
                         valuationInformationAndTaxes: ValuationInformationAndTaxes = ValuationInformationAndTaxes(),
-                        whenAndWhere: WhenAndWhere = WhenAndWhere(),
                         commodity: Option[Commodity] = None,
                         totalGrossMassMeasure: Option[String] = None,
                         packaging: Option[Packaging] = None,
                         borderTransportMeans: Option[BorderTransportMeans] = None,
                         consignment: Option[Consignment] = None,
                         headerCustomsValuation: Option[HeaderCustomsValuation] = None,
-                        itemCustomsValuation: Option[ItemCustomsValuation] = None
+                        itemCustomsValuation: Option[ItemCustomsValuation] = None,
+                        goodsShipment: GoodsShipment = GoodsShipment(destination = None,
+                                                                     exportCountry = None,
+                                                                     governmentAgencyGoodsItem = None)
                       )

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/domain/GoodsShipment.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/domain/GoodsShipment.scala
@@ -16,6 +16,6 @@
 
 package uk.gov.hmrc.cdsimportsddsfrontend.domain
 
-case class WhenAndWhere(destination: Option[Destination] = Some(Destination()),
-                        exportCountry: Option[ExportCountry] = Some(ExportCountry()),
-                        origin: Option[Origin] = Some(Origin()))
+case class GoodsShipment(destination: Option[Destination],
+                         exportCountry: Option[ExportCountry],
+                         governmentAgencyGoodsItem: Option[GovernmentAgencyGoodsItem])

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/domain/GovernmentAgencyGoodsItem.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/domain/GovernmentAgencyGoodsItem.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cdsimportsddsfrontend.domain
+
+case class GovernmentAgencyGoodsItem(origin: Option[Origin])

--- a/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DeclarationXml.scala
+++ b/app/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DeclarationXml.scala
@@ -80,8 +80,8 @@ class DeclarationXml {
           {maybeParty("Buyer", dec.parties.buyer)}
           {dec.consignment.toXml}
           {dec.headerCustomsValuation.toXml}
-          {dec.whenAndWhere.destination.toXml}
-          {dec.whenAndWhere.exportCountry.toXml}
+          {dec.goodsShipment.destination.toXml}
+          {dec.goodsShipment.exportCountry.toXml}
           <GovernmentAgencyGoodsItem>
             <SequenceNumeric>{dec.declarationType.goodsItemNumber}</SequenceNumeric>
             {dec.documentationType.additionalDocument.map(_.toXml)}
@@ -102,7 +102,7 @@ class DeclarationXml {
             <GovernmentProcedure>
               <CurrentCode>{dec.declarationType.additionalProcedureCode}</CurrentCode>
             </GovernmentProcedure>
-            {dec.whenAndWhere.origin.toXml}
+            {dec.goodsShipment.governmentAgencyGoodsItem.flatMap(g => g.origin).flatMap(o => o.toXmlOption).getOrElse(NodeSeq.Empty)}
             {dec.packaging.toXml}
             {dec.documentationType.itemPreviousDocument.map(_.toXml)}
             {maybeValuationAdjustment(dec)}

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/controllers/model/DeclarationViewModelSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/controllers/model/DeclarationViewModelSpec.scala
@@ -34,8 +34,6 @@ class DeclarationViewModelSpec extends WordSpec with Matchers {
 
       val declaration = viewModel.toDeclaration
 
-      declaration.whenAndWhere shouldBe WhenAndWhere()
-
       declaration.commodity shouldBe Some(Commodity(Some("TSP no description required"),
         List(Classification(Some("76071111"), Some("TSP")), Classification(Some("10"), Some("TRC")),
           Classification(Some("1234"), Some("TRA")), Classification(Some("VATZ"), Some("GN"))),
@@ -63,6 +61,10 @@ class DeclarationViewModelSpec extends WordSpec with Matchers {
       declaration.itemCustomsValuation shouldBe Some(ItemCustomsValuation(
         chargeDeduction = Some(ChargeDeduction(typeCode = "item type", currencyAmount = CurrencyAmount(currency = "GBP", amount = "65"))),
         methodCode = Some("1")))
+
+      declaration.goodsShipment.destination shouldBe Some(Destination(countryCode = Some("GB")))
+      declaration.goodsShipment.exportCountry shouldBe Some(ExportCountry(id = Some("FR")))
+      declaration.goodsShipment.governmentAgencyGoodsItem.flatMap(g => g.origin) shouldBe Some(Origin(countryCode = Some("FR"), typeCode = Some("1")))
     }
   }
 }

--- a/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DeclarationXml_WhenAndWhereSpec.scala
+++ b/test/uk/gov/hmrc/cdsimportsddsfrontend/services/xml/DeclarationXml_WhenAndWhereSpec.scala
@@ -27,9 +27,9 @@ class DeclarationXml_WhenAndWhereSpec extends WordSpec with MustMatchers {
     "be populated in the XML at header level" when {
       "the destination country code is present in the data" in {
         val declaration = Declaration(
-          whenAndWhere = WhenAndWhere(
-            destination = Some(Destination(countryCode = Some("FR")))
-          )
+          goodsShipment = GoodsShipment(destination = Some(Destination(countryCode = Some("FR"))),
+                                        exportCountry = None,
+                                        governmentAgencyGoodsItem = None)
         )
 
         val xml: Elem = (new DeclarationXml).fromImportDeclaration(declaration)
@@ -38,9 +38,10 @@ class DeclarationXml_WhenAndWhereSpec extends WordSpec with MustMatchers {
 
       "the export country is present in the data" in {
         val declaration = Declaration(
-          whenAndWhere = WhenAndWhere(
-            exportCountry = Some(ExportCountry(id = Some("NE")))
-          )
+          goodsShipment = GoodsShipment(
+            destination = None,
+            exportCountry = Some(ExportCountry(id = Some("NE"))),
+            governmentAgencyGoodsItem = None)
         )
 
         val xml: Elem = (new DeclarationXml).fromImportDeclaration(declaration)
@@ -49,8 +50,10 @@ class DeclarationXml_WhenAndWhereSpec extends WordSpec with MustMatchers {
 
       "the origin is present in the data" in {
         val declaration = Declaration(
-          whenAndWhere = WhenAndWhere(
-            origin = Some(Origin(countryCode = Some("DL"), typeCode = Some("99")))
+          goodsShipment = GoodsShipment(
+            destination = None,
+            exportCountry = None,
+            governmentAgencyGoodsItem = Some(GovernmentAgencyGoodsItem(origin = Some(Origin(countryCode = Some("DL"), typeCode = Some("99")))))
           )
         )
 
@@ -63,9 +66,7 @@ class DeclarationXml_WhenAndWhereSpec extends WordSpec with MustMatchers {
     "be omitted from XML" when {
       "the destination country data is missing" in {
         val declaration = Declaration(
-          whenAndWhere = WhenAndWhere(
-            destination = Some(Destination(countryCode = None))
-          )
+          goodsShipment = GoodsShipment(destination = None, exportCountry = None, governmentAgencyGoodsItem = None)
         )
 
         val xml: Elem = (new DeclarationXml).fromImportDeclaration(declaration)
@@ -74,9 +75,10 @@ class DeclarationXml_WhenAndWhereSpec extends WordSpec with MustMatchers {
 
       "the export country data is missing" in {
         val declaration = Declaration(
-          whenAndWhere = WhenAndWhere(
-            exportCountry = Some(ExportCountry(id = None))
-          )
+          goodsShipment = GoodsShipment(
+            destination = None,
+            exportCountry = Some(ExportCountry(id = None)),
+            governmentAgencyGoodsItem = None)
         )
 
         val xml: Elem = (new DeclarationXml).fromImportDeclaration(declaration)
@@ -85,8 +87,10 @@ class DeclarationXml_WhenAndWhereSpec extends WordSpec with MustMatchers {
 
       "the origin data is missing" in {
         val declaration = Declaration(
-          whenAndWhere = WhenAndWhere(
-            origin = None
+          goodsShipment = GoodsShipment(
+            destination = None,
+            exportCountry = None,
+            governmentAgencyGoodsItem = Some(GovernmentAgencyGoodsItem(origin = None))
           )
         )
 


### PR DESCRIPTION
Small PR to remove the WhenAndWhere class form the domain and support all the fields via domain classes from the XML schema